### PR TITLE
docs: improve pre-commit hooks and developer setup docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,8 @@ Thumbs.db
 # TODO: (can remove once migration is fully complete)
 .recipes/
 .cookiecutter/state/
+
+# CDK context files
+cdk.context.json
+infrastructure/.coverage
+infrastructure/cdk.out/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,4 @@
-exclude: |
-            (?x)^(
-              uv\.lock|
-              asf_mission_data\.egg-info/|
-              infrastructure/cdk\.out/|
-              infrastructure/\.coverage
-            )$
 fail_fast: true
-default_language_version:
-  python: python3.12
-default_install_hook_types:
-  - pre-commit
 repos:
 #
 # ---------------------------------------------------------------------------- #
@@ -68,8 +57,8 @@ repos:
         exclude: "docs/mkdocs.yml"
 # ------------------------------- 🌳 Git Tools ------------------------------- #
     -   id: check-added-large-files
-        args: ['--maxkb=500']  # set the maximum file size to 500KB
-        name: "🌳 git · Prevent adding files larger than 500KB"
+        args: ['--maxkb=600']  # set the maximum file size to 600KB
+        name: "🌳 git · Prevent adding files larger than 600KB"
     -   id: check-merge-conflict
         name: "🌳 git · Prevent committing unresolved merge conflicts"
     -   id: no-commit-to-branch

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         args: ["-b", dev]
         pass_filenames: false
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.2
+    rev: v0.15.5
     hooks:
     -   id: ruff-format
     -   id: ruff-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,7 @@ repos:
         name: "✨ misc-files · Ensure files end with a newline"
     -   id: trailing-whitespace
         name: "✨ misc-files · Remove trailing whitespace"
+        args: ['--markdown-linebreak-ext=md']
     -   id: check-yaml # validates YAML syntax
         name: "✨ misc-files · Validate YAML files"
         exclude: "docs/mkdocs.yml"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,3 @@
-fail_fast: true
 repos:
 #
 # ---------------------------------------------------------------------------- #
@@ -24,10 +23,11 @@ repos:
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.5
     hooks:
+    -   id: ruff-check
+        args: [--fix]
+        name: "🐍 python · Lint and fix with Ruff"
     -   id: ruff-format
         name: "🐍 python · Format with Ruff"
-    -   id: ruff-check
-        name: "🐍 python · Check with Ruff"
 
 -   repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.25

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,24 +1,78 @@
+exclude: |
+            (?x)^(
+              uv\.lock|
+              asf_mission_data\.egg-info/|
+              infrastructure/cdk\.out/|
+              infrastructure/\.coverage
+            )$
+fail_fast: true
+default_language_version:
+  python: python3.12
+default_install_hook_types:
+  - pre-commit
 repos:
+#
+# ---------------------------------------------------------------------------- #
+#                                Pre-Commit Hooks                             #
+# ---------------------------------------------------------------------------- #
 -   repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
     rev: v0.9.0
     hooks:
     -   id: pre-commit-update
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+        name: "🔄 pre-commit update · Update pre-commit hooks to the latest versions"
+
+# ----------------------------- 🔒 Security Tools ---------------------------- #
+-   repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.0
     hooks:
-    -   id: check-added-large-files # prevent accidentally adding large files to the repo
-        args: ['--maxkb=500']  # Flag files over 500KB
-    -   id: check-merge-conflict # prevent committing unresolved merge conflicts
-    -   id: end-of-file-fixer # ensure files end with a newline
-    -   id: trailing-whitespace # remove trailing whitespace
-    -   id: check-toml # validates pyproject.toml syntax
-    -   id: check-yaml # validates YAML syntax
-        exclude: "docs/mkdocs.yml"
-    -   id: no-commit-to-branch
-        args: ["-b", dev]
-        pass_filenames: false
+    -   id: gitleaks
+        name: "🔒 security · Detect hardcoded secrets"
+
+
+# --------------------------- Code Quality Tools -------------------------- #
+
+    ### Python Tools ###
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.5
     hooks:
     -   id: ruff-format
+        name: "🐍 python · Format with Ruff"
     -   id: ruff-check
+        name: "🐍 python · Check with Ruff"
+
+-   repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.25
+    hooks:
+    -   id: validate-pyproject
+        name: "🐍 python · Validate pyproject.toml"
+        additional_dependencies: ["validate-pyproject-schema-store[all]"]
+
+    ### Data & Config Validation ###
+-   repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.37.0
+    hooks:
+    -   id: check-github-workflows
+        name: "🐙 github-actions · Validate gh workflow files"
+        args: ["--verbose"]
+
+    ### Misc File Types ###
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+    -   id: end-of-file-fixer
+        name: "✨ misc-files · Ensure files end with a newline"
+    -   id: trailing-whitespace
+        name: "✨ misc-files · Remove trailing whitespace"
+    -   id: check-yaml # validates YAML syntax
+        name: "✨ misc-files · Validate YAML files"
+        exclude: "docs/mkdocs.yml"
+# ------------------------------- 🌳 Git Tools ------------------------------- #
+    -   id: check-added-large-files
+        args: ['--maxkb=500']  # set the maximum file size to 500KB
+        name: "🌳 git · Prevent adding files larger than 500KB"
+    -   id: check-merge-conflict
+        name: "🌳 git · Prevent committing unresolved merge conflicts"
+    -   id: no-commit-to-branch
+        name: "🌳 git · Prevent committing directly to protected branches"
+        args: ["-b", dev]
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -47,6 +47,55 @@ source .env
 uv run python -m asf_mission_data.pipeline.example.handler
 ```
 
+## Developer setup
+
+### Pre-commit and code formatting
+
+This project uses **pre-commit hooks** and **ruff** to automatically format and lint code. The best experience is to set up your editor to format on save, so issues are fixed before they reach the pre-commit hook.
+
+#### VS Code setup (recommended)
+
+1. **Install the Ruff extension** - Search for "Ruff" in VS Code extensions and install the official Astral extension
+2. **Add to `.vscode/settings.json`** (Select the "Preferences: Open Workspace Settings (JSON)" command in the Command Palette (Mac: ⇧⌘P Win: Ctrl + shift + P)):
+
+```json
+{
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll": "explicit"
+    }
+  }
+}
+```
+
+This auto-formats your code every time you save, so ruff issues are fixed before you commit.
+
+#### Command line
+
+You can also manually format/check code:
+
+```bash
+# Auto-fix formatting and common issues
+uv run ruff format .
+
+# Check for remaining linting issues
+uv run ruff check . --fix
+```
+
+#### Pre-commit hooks
+
+Pre-commit hooks run automatically when you commit. If you see issues at commit time:
+
+```bash
+# Install the pre-commit hooks (one-time setup)
+uv run pre-commit install
+
+# This will run on every git commit and auto-fix what it can
+# If it makes changes, stage them and commit again
+```
+
 ## Project structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This project uses **pre-commit hooks** and **ruff** to automatically format and 
 #### VS Code setup (recommended)
 
 1. **Install the Ruff extension** - Search for "Ruff" in VS Code extensions and install the official Astral extension
-2. **Add to `.vscode/settings.json`** (Select the "Preferences: Open Workspace Settings (JSON)" command in the Command Palette (Mac: ⇧⌘P Win: Ctrl + shift + P)):
+2. **Add to `.vscode/settings.json`** (You may need to first select the "Preferences: Open Workspace Settings (JSON)" command in the Command Palette (Mac: ⇧⌘P Win: Ctrl + shift + P)):
 
 ```json
 {
@@ -94,6 +94,12 @@ uv run pre-commit install
 
 # This will run on every git commit and auto-fix what it can
 # If it makes changes, stage them and commit again
+
+# Test hooks without committing
+uv run pre-commit run --all-files
+
+# Commit without running hooks
+git commit --no-verify
 ```
 
 ## Project structure

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ uv run pre-commit install
 # If it makes changes, stage them and commit again
 
 # Test hooks without committing
+uv run pre-commit run
+# or
 uv run pre-commit run --all-files
 
 # Commit without running hooks

--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ This project uses **pre-commit hooks** and **ruff** to automatically format and 
     "editor.defaultFormatter": "charliermarsh.ruff",
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.fixAll": "explicit"
+      "source.fixAll.ruff": "explicit"
     }
   }
 }
 ```
 
-This auto-formats your code every time you save, so ruff issues are fixed before you commit.
+This auto-formats your Python files every time you save, so ruff issues are fixed before you commit.
 
 #### Command line
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ select = [
 #   "D"   - docstrings (add once pipeline patterns are settled)
 #   "N"   - naming conventions
 #   "C"   - comprehensions + complexity
+#
+# Uncomment to ignore specific rules:
+# ignore = []
 
 [tool.ruff.lint.isort]
 known-first-party = ["asf_mission_data"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "types-pyyaml>=6.0.12.20250915",
     "types-requests>=2.32.4.20260107",
     "pytest-mock>=3.15.1",
+    "validate-pyproject[all]>=0.25",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/uv.lock
+++ b/uv.lock
@@ -262,6 +262,7 @@ dev = [
     { name = "sf-hamilton", extra = ["lsp", "visualization"] },
     { name = "types-pyyaml" },
     { name = "types-requests" },
+    { name = "validate-pyproject", extra = ["all"] },
 ]
 
 [package.metadata]
@@ -292,6 +293,7 @@ dev = [
     { name = "sf-hamilton", extras = ["lsp", "visualization"], specifier = ">=1.89.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
     { name = "types-requests", specifier = ">=2.32.4.20260107" },
+    { name = "validate-pyproject", extras = ["all"], specifier = ">=0.25" },
 ]
 
 [[package]]
@@ -2918,6 +2920,15 @@ wheels = [
 ]
 
 [[package]]
+name = "trove-classifiers"
+version = "2026.1.14.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/43/7935f8ea93fcb6680bc10a6fdbf534075c198eeead59150dd5ed68449642/trove_classifiers-2026.1.14.14.tar.gz", hash = "sha256:00492545a1402b09d4858605ba190ea33243d361e2b01c9c296ce06b5c3325f3", size = 16997, upload-time = "2026-01-14T14:54:50.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/4a/2e5583e544bc437d5e8e54b47db87430df9031b29b48d17f26d129fa60c0/trove_classifiers-2026.1.14.14-py3-none-any.whl", hash = "sha256:1f9553927f18d0513d8e5ff80ab8980b8202ce37ecae0e3274ed2ef11880e74d", size = 14197, upload-time = "2026-01-14T14:54:49.067Z" },
+]
+
+[[package]]
 name = "typeguard"
 version = "4.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3040,6 +3051,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
+]
+
+[[package]]
+name = "validate-pyproject"
+version = "0.25"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastjsonschema" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/d8/45a82408619c306d0083afcf6142617201b2647a82e9a7d4c902e837274c/validate_pyproject-0.25.tar.gz", hash = "sha256:e68c12d1cb0d8ddc269ffc42875a81727ddb7865000aa6d2f77d833b55c53f0b", size = 118662, upload-time = "2026-02-02T17:31:07.089Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ee/e9c95cda829131f71a8dff5ce0406059fd16e591c074414e31ada19ba7c3/validate_pyproject-0.25-py3-none-any.whl", hash = "sha256:f9d05e2686beff82f9ea954f582306b036ced3d3feb258c1110f2c2a495b1981", size = 54942, upload-time = "2026-02-02T17:31:05.489Z" },
+]
+
+[package.optional-dependencies]
+all = [
+    { name = "packaging" },
+    { name = "trove-classifiers" },
 ]
 
 [[package]]


### PR DESCRIPTION
 Closes #17  

## Summary

- **Enhanced pre-commit hooks**: Added gitleaks (secret detection), ruff-check with `--fix`, validate-pyproject, and check-github-workflows; removed redundant check-toml in favour of validate-pyproject
- **Improved hook naming**: All hooks now have descriptive emoji-prefixed names grouped by category (security, python, data/config, misc-files, git) for easier reading in terminal output
- **Fixed trailing whitespace for Markdown**: Added `--markdown-linebreak-ext=md` to stop `trailing-whitespace` hook from stripping out intentional two-space line breaks used for `<br>` in `.md` files
- **Increased large file limit**: Raised from 500KB to 600KB
- **Corrected ruff hook order**: `ruff-check --fix` runs before `ruff-format` per ruff docs
- **Updated .gitignore**: Added CDK context files (`cdk.context.json`, `infrastructure/.coverage`, `infrastructure/cdk.out/`)
- **Developer setup docs**: Added a new "Developer setup" section to the README covering VS Code ruff extension setup (format on save), command-line ruff usage, and pre-commit workflow instructions

## Test plan

- [X] Run `uv run pre-commit run --all-files` and verify all hooks pass
- [X] Confirm gitleaks does not flag any existing files
- [X] Confirm VS Code settings snippet in README works as described