### PR TITLE
47 feat prod workflow

### DIFF
--- a/.github/workflows/promote-to-prod.yaml
+++ b/.github/workflows/promote-to-prod.yaml
@@ -1,0 +1,59 @@
+# Promotes the tested dev image to production by re-tagging it in ECR.
+#
+# This runs automatically when a PR from dev is merged into the prod branch.
+# It does NOT rebuild the Docker image — it takes the exact image that was
+# tested in dev and tags it as prod-latest, so what you tested is what runs.
+#
+# No pipelines are triggered by this workflow. Pipelines run either on
+# schedule (EventBridge) or manually via the "Run pipeline (prod)" workflow.
+
+name: Promote dev to prod
+
+on:
+  push:
+    branches:
+      - prod
+
+env:
+  AWS_REGION: eu-west-2
+  ECR_REPO: asf-mission-data
+
+jobs:
+    promote:
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        permissions:
+          contents: read
+          id-token: write # Required for OIDC authentication with AWS
+
+        steps:
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v6
+              with:
+                role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/asf-github-actions-prod
+                aws-region: ${{ env.AWS_REGION }}
+                role-session-name: GitHubActions-Promote-${{ github.run_id }}
+
+            # Re-tag rather than rebuild: fetch the dev-latest manifest from ECR
+            # and push it back with the prod-latest tag. No Docker needed.
+            - name: Re-tag dev-latest as prod-latest
+              run: |
+                MANIFEST=$(aws ecr batch-get-image \
+                    --repository-name ${{ env.ECR_REPO }} \
+                    --image-ids imageTag=dev-latest \
+                    --query 'images[0].imageManifest' \
+                    --output text)
+
+                if [ "$MANIFEST" = "None" ] || [ -z "$MANIFEST" ]; then
+                    echo "::error::No dev-latest image found in ECR"
+                    exit 1
+                fi
+
+                aws ecr put-image \
+                    --repository-name ${{ env.ECR_REPO }} \
+                    --image-tag prod-latest \
+                    --image-manifest "$MANIFEST"
+
+            - name: Summary
+              run: |
+                echo "### Promoted dev-latest → prod-latest" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/run-pipeline-prod.yaml
+++ b/.github/workflows/run-pipeline-prod.yaml
@@ -1,4 +1,4 @@
-name: Test pipeline in dev
+name: Run pipeline in prod
 
 on:
   workflow_dispatch:
@@ -17,11 +17,6 @@ on:
           - silver
           - gold
         default: all
-      image_tag:
-        description: 'ECR image tag to use for the pipeline run. Leave as dev-latest for normal runs. For testing branches, paste the tag from the build-and-push summary.'
-        required: false
-        type: 'string'
-        default: dev-latest
 
 env:
   AWS_REGION: eu-west-2
@@ -34,6 +29,7 @@ jobs:
     # actions minutes
     timeout-minutes: 5
     # This is for OIDC authentication
+    environment: prod
     permissions:
       contents: read
       id-token: write
@@ -45,7 +41,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/asf-github-actions-dev
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/asf-github-actions-prod
           aws-region: ${{ env.AWS_REGION }}
           # Including the run ID so we can trace which GitHub Actions run made which API calls in CloudTrail
           role-session-name: GitHubActions-RunPipeline-${{ github.run_id }}
@@ -58,4 +54,4 @@ jobs:
 
       - name: Trigger pipeline
         run: |
-          uv run python scripts/trigger_pipeline.py ${{ inputs.pipeline }} --environment dev --stage ${{ inputs.stage }} --image-tag ${{ inputs.image_tag }}
+          uv run python scripts/trigger_pipeline.py ${{ inputs.pipeline }} --environment prod --stage ${{ inputs.stage }}

--- a/.github/workflows/test-pipeline-dev.yaml
+++ b/.github/workflows/test-pipeline-dev.yaml
@@ -1,4 +1,4 @@
-name: Run pipeline
+name: Test pipeline (dev)
 
 on:
   workflow_dispatch:
@@ -23,17 +23,8 @@ on:
         type: 'string'
         default: dev-latest
 
-# Passes the infra values through to trigger_pipeline.py.
-# For now its just dev but when we are out of POC and using
-# prod we can make this a matrix (or add a separate workflow possibly)
-# REPLACE SECURITY GROUPS IF YOU TEAR DOWN THE STACK
 env:
   AWS_REGION: eu-west-2
-  ECS_CLUSTER: asf-mission-data-dev
-  ECS_TASK_FAMILY: asf-mission-data-dev
-  ECS_CAPACITY_PROVIDER: FARGATE
-  ECS_SUBNETS: "subnet-5cc6e511,subnet-eb6fcb82,subnet-1de6f466"
-  ECS_SECURITY_GROUPS: "sg-0539fd44b1f27895b"
 
 jobs:
   trigger:
@@ -67,4 +58,4 @@ jobs:
 
       - name: Trigger pipeline
         run: |
-          uv run python scripts/trigger_pipeline.py ${{ inputs.pipeline }} --stage ${{ inputs.stage }} --image-tag ${{ inputs.image_tag }}
+          uv run python scripts/trigger_pipeline.py ${{ inputs.pipeline }} --environment dev --stage ${{ inputs.stage }} --image-tag ${{ inputs.image_tag }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
 
     ### Python Tools ###
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.14
+    rev: v0.15.15
     hooks:
     -   id: ruff-check
         args: [--fix]

--- a/scripts/trigger_pipeline.py
+++ b/scripts/trigger_pipeline.py
@@ -3,6 +3,7 @@
 Usage:
     python scripts/trigger_pipeline.py example --stage all
     python scripts/trigger_pipeline.py <pipeline_name> --stage bronze
+    python scripts/trigger_pipeline.py <pipeline_name> --environment prod
     python scripts/trigger_pipeline.py <pipeline_name> --capacity-provider FARGATE_SPOT
 """
 
@@ -15,10 +16,15 @@ from typing import Any
 import boto3
 from botocore.exceptions import BotoCoreError, ClientError
 
-CLUSTER = os.environ.get("ECS_CLUSTER", "asf-mission-data-dev")
-TASK_FAMILY = os.environ.get("ECS_TASK_FAMILY", "asf-mission-data-dev")
-SUBNET_IDS = os.environ.get("ECS_SUBNETS", "subnet-5cc6e511,subnet-eb6fcb82,subnet-1de6f466").split(",")
 AWS_REGION = os.environ.get("AWS_REGION", "eu-west-2")
+
+
+@dataclass(frozen=True)
+class InfraConfig:
+    cluster: str
+    task_family: str
+    subnet_ids: list[str]
+    security_group_ids: list[str]
 
 
 @dataclass(frozen=True)
@@ -42,29 +48,39 @@ def emit_github_actions_annotation(level: str, message: str) -> None:
     print(f"::{level}::{escape_github_actions_value(message)}")
 
 
-def get_security_group_ids() -> list[str]:
-    raw_value = os.environ.get("ECS_SECURITY_GROUPS")
-    if not raw_value:
-        raise ValueError("ECS_SECURITY_GROUPS environment variable is required")
-
-    return raw_value.split(",")
+def get_infra_config(environment: str) -> InfraConfig:
+    """Look up infrastructure values from CloudFormation stack outputs."""
+    cfn = boto3.client("cloudformation", region_name=AWS_REGION)
+    stack_name = f"asf-core-{environment}"
+    response = cfn.describe_stacks(StackName=stack_name)
+    outputs = {o["OutputKey"]: o["OutputValue"] for o in response["Stacks"][0]["Outputs"]}
+    return InfraConfig(
+        cluster=outputs["ClusterArn"],
+        task_family=f"asf-mission-data-{environment}",
+        subnet_ids=outputs["SubnetIds"].split(","),
+        security_group_ids=[outputs["SecurityGroupId"]],
+    )
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run a pipeline on ECS Fargate.")
     parser.add_argument("pipeline", help="Pipeline name (must match a key in pipelines.yaml)")
     parser.add_argument(
+        "--environment",
+        choices=["dev", "prod"],
+        default=os.environ.get("ASF_ENVIRONMENT", "dev"),
+        help="Target environment (default: ASF_ENVIRONMENT env var or dev)",
+    )
+    parser.add_argument(
         "--stage",
         choices=["all", "bronze", "silver", "gold"],
         default="all",
         help="Which stage to run (default: all)",
     )
-    # os.environ.get fallback is for local users who prefer setting env vars over typing long flags
-    # CLI arg takes precedence, env var is the fallback, dev-latest is last resort
     parser.add_argument(
         "--image-tag",
-        default=os.environ.get("IMAGE_TAG", "dev-latest"),
-        help="ECR image tag to run (default: IMAGE_TAG env var or dev-latest)",
+        default=None,
+        help="ECR image tag to run (default: {environment}-latest)",
     )
     parser.add_argument(
         "--capacity-provider",
@@ -72,7 +88,10 @@ def parse_args() -> argparse.Namespace:
         default=os.environ.get("ECS_CAPACITY_PROVIDER", "FARGATE"),
         help="Which ECS capacity provider to use (default: ECS_CAPACITY_PROVIDER or FARGATE)",
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.image_tag is None:
+        args.image_tag = f"{args.environment}-latest"
+    return args
 
 
 def get_app_container_image(
@@ -109,12 +128,12 @@ def ensure_image_tag_exists(image_uri: str, image_tag: str) -> None:
     raise ValueError(f"Could not find the image tag '{image_tag}' in ECR repository '{repository_name}'")
 
 
-def resolve_task_definition(image_tag: str) -> ResolvedTaskDefinition:
+def resolve_task_definition(image_tag: str, infra: InfraConfig, environment: str) -> ResolvedTaskDefinition:
     ecsclient = boto3.client("ecs", region_name=AWS_REGION)
-    response = ecsclient.describe_task_definition(taskDefinition=TASK_FAMILY)
+    response = ecsclient.describe_task_definition(taskDefinition=infra.task_family)
     current = response["taskDefinition"]
 
-    if image_tag == "dev-latest":
+    if image_tag == f"{environment}-latest":
         return ResolvedTaskDefinition(
             task_definition=current["taskDefinitionArn"],
             app_image=get_app_container_image(current["containerDefinitions"]),
@@ -156,9 +175,9 @@ def resolve_task_definition(image_tag: str) -> ResolvedTaskDefinition:
     )
 
 
-def run_task(pipeline: str, stage: str, capacity_provider: str, task_definition: str) -> None:
+def run_task(pipeline: str, stage: str, capacity_provider: str, task_definition: str, infra: InfraConfig) -> None:
     params: dict[str, Any] = {
-        "cluster": CLUSTER,
+        "cluster": infra.cluster,
         "taskDefinition": task_definition,
         "count": 1,
         "capacityProviderStrategy": [
@@ -169,8 +188,8 @@ def run_task(pipeline: str, stage: str, capacity_provider: str, task_definition:
         ],
         "networkConfiguration": {
             "awsvpcConfiguration": {
-                "subnets": SUBNET_IDS,
-                "securityGroups": get_security_group_ids(),
+                "subnets": infra.subnet_ids,
+                "securityGroups": infra.security_group_ids,
                 "assignPublicIp": "ENABLED",
             }
         },
@@ -201,18 +220,26 @@ def run_task(pipeline: str, stage: str, capacity_provider: str, task_definition:
 
     task_arn = response["tasks"][0]["taskArn"]
     task_id = task_arn.split("/")[-1]
+    cluster_name = infra.cluster.split("/")[-1]
     print(f"Task started: {task_id}")
     print(f"Capacity:     {capacity_provider}")
     print(
-        f"Watch it:     aws ecs describe-tasks --cluster {CLUSTER} --tasks {task_id}"  # noqa: E501
+        f"Watch it:     aws ecs describe-tasks --cluster {cluster_name} --tasks {task_id}"  # noqa: E501
     )
-    print(f"Logs:         aws logs tail /ecs/{CLUSTER} --follow")
+    print(f"Logs:         aws logs tail /ecs/{cluster_name} --follow")
 
 
 if __name__ == "__main__":
     args = parse_args()
     try:
-        resolved = resolve_task_definition(args.image_tag)
+        infra = get_infra_config(args.environment)
+    except (BotoCoreError, ClientError) as exc:
+        emit_github_actions_annotation("error", f"Error looking up infrastructure: {exc}")
+        print(f"Error looking up infrastructure for '{args.environment}': {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        resolved = resolve_task_definition(args.image_tag, infra, args.environment)
     except (BotoCoreError, ClientError, ValueError) as exc:
         emit_github_actions_annotation("error", f"Error resolving task definition: {exc}")
         print(f"Error resolving task definition: {exc}", file=sys.stderr)
@@ -227,4 +254,5 @@ if __name__ == "__main__":
         args.stage,
         args.capacity_provider,
         resolved.task_definition,
+        infra,
     )

--- a/tests/test_trigger_pipeline.py
+++ b/tests/test_trigger_pipeline.py
@@ -10,6 +10,7 @@ def test_parse_args_defaults_to_standard_fargate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("ECS_CAPACITY_PROVIDER", raising=False)
+    monkeypatch.delenv("ASF_ENVIRONMENT", raising=False)
     monkeypatch.setattr(
         "sys.argv",
         ["trigger_pipeline.py", "example", "--stage", "silver"],
@@ -21,6 +22,7 @@ def test_parse_args_defaults_to_standard_fargate(
     assert args.pipeline == "example"
     assert args.stage == "silver"
     assert args.capacity_provider == "FARGATE"
+    assert args.environment == "dev"
     assert args.image_tag == "dev-latest"
 
 
@@ -60,21 +62,17 @@ def test_emit_github_actions_annotation_is_noop_when_disabled(
     assert captured.out == ""
 
 
-def test_get_security_group_ids_raises_when_env_missing(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.delenv("ECS_SECURITY_GROUPS", raising=False)
-
-    with pytest.raises(ValueError, match="ECS_SECURITY_GROUPS environment variable is required"):
-        trigger_pipeline.get_security_group_ids()
+FAKE_INFRA = trigger_pipeline.InfraConfig(
+    cluster="arn:aws:ecs:eu-west-2:123456789012:cluster/asf-mission-data-dev",
+    task_family="asf-mission-data-dev",
+    subnet_ids=["subnet-abc", "subnet-def"],
+    security_group_ids=["sg-0539fd44b1f27895b"],
+)
 
 
 def test_run_task_uses_explicit_capacity_provider(
-    monkeypatch: pytest.MonkeyPatch,
     mocker: pytest_mock.MockerFixture,
 ) -> None:
-    monkeypatch.setenv("ECS_SECURITY_GROUPS", "sg-0539fd44b1f27895b")
-
     ecs_client = mocker.Mock()
     ecs_client.run_task.return_value = {
         "tasks": [{"taskArn": "arn:aws:ecs:eu-west-2:123456789012:task/asf-mission-data-dev/task-123"}],
@@ -82,7 +80,7 @@ def test_run_task_uses_explicit_capacity_provider(
     }
     boto_client = mocker.patch("scripts.trigger_pipeline.boto3.client", return_value=ecs_client)
 
-    trigger_pipeline.run_task("example", "all", "FARGATE", "asf-mission-data-dev")
+    trigger_pipeline.run_task("example", "all", "FARGATE", "asf-mission-data-dev", FAKE_INFRA)
 
     boto_client.assert_called_once_with("ecs", region_name=trigger_pipeline.AWS_REGION)
     ecs_client.run_task.assert_called_once()
@@ -113,14 +111,14 @@ def test_resolve_task_definition_returns_task_family_for_dev_latest(mocker):
     }
     boto_client = mocker.patch("scripts.trigger_pipeline.boto3.client", return_value=ecs_client)
 
-    result = trigger_pipeline.resolve_task_definition("dev-latest")
+    result = trigger_pipeline.resolve_task_definition("dev-latest", FAKE_INFRA, "dev")
 
     assert result == trigger_pipeline.ResolvedTaskDefinition(
         task_definition="arn:aws:ecs:eu-west-2:123:task-definition/asf-mission-data-dev:6",
         app_image="123.dkr.ecr.eu-west-2.amazonaws.com/asf-mission-data:dev-latest",
     )
     boto_client.assert_called_once_with("ecs", region_name=trigger_pipeline.AWS_REGION)
-    ecs_client.describe_task_definition.assert_called_once_with(taskDefinition=trigger_pipeline.TASK_FAMILY)
+    ecs_client.describe_task_definition.assert_called_once_with(taskDefinition=FAKE_INFRA.task_family)
 
 
 def test_resolve_task_definition_registers_new_revision_for_feature_tag(
@@ -163,7 +161,7 @@ def test_resolve_task_definition_registers_new_revision_for_feature_tag(
 
     mocker.patch("scripts.trigger_pipeline.boto3.client", side_effect=boto3_client)
 
-    result = trigger_pipeline.resolve_task_definition("56-feature-new-pipeline-latest")
+    result = trigger_pipeline.resolve_task_definition("56-feature-new-pipeline-latest", FAKE_INFRA, "dev")
 
     # correct image was registered
     registered_containers = ecs_client.register_task_definition.call_args.kwargs["containerDefinitions"]
@@ -179,12 +177,22 @@ def test_resolve_task_definition_registers_new_revision_for_feature_tag(
     )
 
 
-def test_parse_args_reads_image_tag_from_env(monkeypatch):
+def test_parse_args_image_tag_defaults_to_environment(monkeypatch):
     """
-    When IMAGE_TAG env var is set, parse_args picks it up as the default
+    When no --image-tag is given, it defaults to {environment}-latest
     """
-    monkeypatch.setenv("IMAGE_TAG", "56-feature-new-pipeline-latest")
-    monkeypatch.setattr("sys.argv", ["trigger_pipeline.py", "example"])
+    monkeypatch.setattr("sys.argv", ["trigger_pipeline.py", "example", "--environment", "prod"])
+
+    args = trigger_pipeline.parse_args()
+
+    assert args.image_tag == "prod-latest"
+
+
+def test_parse_args_image_tag_override(monkeypatch):
+    """
+    When --image-tag is given explicitly, it overrides the default
+    """
+    monkeypatch.setattr("sys.argv", ["trigger_pipeline.py", "example", "--image-tag", "56-feature-new-pipeline-latest"])
 
     args = trigger_pipeline.parse_args()
 
@@ -229,6 +237,6 @@ def test_resolve_task_definition_raises_for_missing_image_tag(mocker) -> None:
     mocker.patch("scripts.trigger_pipeline.boto3.client", side_effect=boto3_client)
 
     with pytest.raises(ValueError, match="Could not find the image tag '44-feat-image'"):
-        trigger_pipeline.resolve_task_definition("44-feat-image")
+        trigger_pipeline.resolve_task_definition("44-feat-image", FAKE_INFRA, "dev")
 
     ecs_client.register_task_definition.assert_not_called()


### PR DESCRIPTION
Set up the dev-to-prod workflow for promoting and running pipelines across environments.                                       

Changes:
  - trigger_pipeline.py now accepts --environment flag and looks up infrastructure (cluster, subnets, security group) from
  CloudFormation stack outputs instead of hardcoded env vars
  - Renamed "Run pipeline" workflow to "Test pipeline (dev)"
  - Created "Run pipeline (prod)" workflow with GitHub environment approval gate
  - Created "Promote to prod" workflow that re-tags dev-latest as prod-latest in ECR on merge to prod
  - Removed dead ECS stack code (infrastructure/stacks/ecs/) and cleaned up app.py to use a single CoreStack per environment
  - Updated tests to match new function signatures

  Fixes #47

To test the full flow once merged:
  1. Confirm build-and-push runs on merge to dev and creates dev-latest
  2. Create a PR from dev → prod, merge it
  3. Check the "Promote dev to prod" workflow runs and prod-latest appears in ECR
  4. Trigger "Run pipeline (prod)" and confirm the approval gate fires

  Please pay special attention to the get_infra_config() function in trigger_pipeline.py — it reads CloudFormation outputs at
  runtime, so the GitHub Actions role needs cloudformation:Describe* permission (already granted in the CDK stack).

# Checklist:

- [ ] I have checked the code runs
- [ ] I have tested the code
- [ ] I have run `pre-commit` and addressed any issues not automatically fixed
- [ ] I have merged any new changes from `dev`
- [ ] I have documented the code
  - [ ] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [ ] I have explained this PR above
- [ ] I have requested a code review
