### PR TITLE
refactor: consolidate locate_latest_bronze and locate_latest_silver into locate_latest

### DIFF
--- a/asf_mission_data/pipeline/energy_price_cap_levels_annex_9/gold.py
+++ b/asf_mission_data/pipeline/energy_price_cap_levels_annex_9/gold.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 def silver_energy_price_cap_annex_9_dataset(dataset_prefix: str, silver_table_prefix: str) -> str:
     """Latest silver-level dataset for Energy Price Cap Annex 9."""
-    return storage.locate_latest_silver(dataset_prefix, silver_table_prefix)
+    return storage.locate_latest(dataset_prefix, silver_table_prefix, "silver")
 
 
 def silver_df(silver_energy_price_cap_annex_9_dataset: str) -> pd.DataFrame:

--- a/asf_mission_data/pipeline/energy_price_cap_levels_annex_9/silver.py
+++ b/asf_mission_data/pipeline/energy_price_cap_levels_annex_9/silver.py
@@ -27,7 +27,7 @@ logger = setup_logging(__name__)
 
 def bronze_energy_price_cap_annex_9_file(dataset_prefix: str) -> str:
     """Latest bronze-level dataset for Energy Price Cap Annex 9."""
-    return storage.locate_latest_bronze(dataset_prefix, "file")
+    return storage.locate_latest(dataset_prefix, "file", "bronze")
 
 
 def excel_sheet_df(bronze_energy_price_cap_annex_9_file: str, sheet_name: str) -> pd.DataFrame:
@@ -37,7 +37,7 @@ def excel_sheet_df(bronze_energy_price_cap_annex_9_file: str, sheet_name: str) -
 
 def bronze_energy_price_cap_annex_9_metadata(dataset_prefix: str) -> dict:
     """Load metadata associated with the latest bronze dataset."""
-    metadata_uri = storage.locate_latest_bronze(dataset_prefix, "metadata")
+    metadata_uri = storage.locate_latest(dataset_prefix, "metadata", "bronze")
     return storage.read_json(metadata_uri)
 
 

--- a/asf_mission_data/pipeline/example/silver.py
+++ b/asf_mission_data/pipeline/example/silver.py
@@ -20,7 +20,7 @@ logger = setup_logging(__name__)
 
 def bronze_bank_holidays_uri(dataset_prefix: str) -> str:
     """Locate the latest bronze bank holidays JSON file."""
-    uri = storage.locate_latest_bronze(dataset_prefix, "file")
+    uri = storage.locate_latest(dataset_prefix, "file", "bronze")
     if uri is None:
         raise FileNotFoundError(f"No latest bronze file found for dataset prefix '{dataset_prefix}'.")
     logger.info("Located bronze file: %s", uri)
@@ -34,7 +34,7 @@ def bronze_bank_holidays_json(bronze_bank_holidays_uri: str) -> dict[str, Any]:
 
 def bronze_bank_holidays_metadata(dataset_prefix: str) -> dict[str, Any]:
     """Load metadata for the latest bronze bank holidays ingest."""
-    uri = storage.locate_latest_bronze(dataset_prefix, "metadata")
+    uri = storage.locate_latest(dataset_prefix, "metadata", "bronze")
     if uri is None:
         raise FileNotFoundError(f"No latest bronze metadata found for dataset prefix '{dataset_prefix}'.")
     logger.info("Located bronze metadata: %s", uri)

--- a/asf_mission_data/pipeline/heat_pump_deployment_statistics/silver.py
+++ b/asf_mission_data/pipeline/heat_pump_deployment_statistics/silver.py
@@ -32,7 +32,7 @@ def bronze_heat_pump_deployment_statistics_file(dataset_prefix: str) -> str:
     Returns:
         str: URI or file path to the latest bronze Excel file.
     """
-    return storage.locate_latest_bronze(dataset_prefix, "file")
+    return storage.locate_latest(dataset_prefix, "file", "bronze")
 
 
 def bronze_heat_pump_deployment_statistics_metadata(dataset_prefix: str) -> dict[str, str]:
@@ -44,7 +44,7 @@ def bronze_heat_pump_deployment_statistics_metadata(dataset_prefix: str) -> dict
     Returns:
         dict: Dictionary containing metadata fields such as publication date and source information.
     """
-    metadata_uri = storage.locate_latest_bronze(dataset_prefix, "metadata")
+    metadata_uri = storage.locate_latest(dataset_prefix, "metadata", "bronze")
     return storage.read_json(metadata_uri)
 
 

--- a/asf_mission_data/storage.py
+++ b/asf_mission_data/storage.py
@@ -241,11 +241,24 @@ def save_dag(
     persist(historical_file, dag_image)
 
 
-def _locate_latest(
+def locate_latest(
     dataset_prefix: str,
     sub_prefix: str,
     layer_prefix: str,
 ) -> str:
+    """Locate the latest file under a given storage prefix.
+
+    Args:
+        dataset_prefix (str): Dataset identifier used to namespace storage.
+        sub_prefix (str): Sub-prefix to locate (e.g. 'file', 'metadata', or a table name).
+        layer_prefix (str): Storage namespace representing the data layer (e.g. 'bronze', 'silver').
+
+    Raises:
+        FileNotFoundError: If the prefix or files do not exist.
+
+    Returns:
+        str: URI of the latest file.
+    """
     _, data_root = _initialise_environment()
 
     uri_prefix = f"{data_root}/data/{layer_prefix}/{dataset_prefix}/latest/{sub_prefix}"
@@ -263,32 +276,6 @@ def _locate_latest(
     logger.info("Found %d item(s) under prefix: %s", len(files), uri_prefix)
 
     return cast(str, fs.unstrip_protocol(files[0]))
-
-
-def locate_latest_bronze(
-    dataset_prefix: str,
-    file_or_metadata: str = "file",
-    layer_prefix: str = "bronze",
-) -> str:
-    """Locate the latest bronze dataset file or metadata.
-
-    Args:
-        dataset_prefix (str): Dataset identifier used to namespace storage.
-        file_or_metadata (str): Either 'file' or 'metadata'. Defaults to "file".
-        layer_prefix (str): Storage namespace representing the data layer.
-            Defaults to "bronze".
-
-    Raises:
-        ValueError: If `file_or_metadata` is not 'file' or 'metadata'.
-        FileNotFoundError: If the prefix or files do not exist.
-
-    Returns:
-        str: URI of the latest bronze file or metadata.
-    """
-    if file_or_metadata not in ["file", "metadata"]:
-        raise ValueError(f"Invalid file type '{file_or_metadata}', must be 'file' or 'metadata'.")
-
-    return _locate_latest(dataset_prefix, file_or_metadata, layer_prefix)
 
 
 def read_excel_sheet(excel_uri: str, sheet_name: str) -> pd.DataFrame:
@@ -387,28 +374,6 @@ def ingest_to_silver(
 
     delete_prefix(f"{base_path}/latest/{df_name}")
     persist_df_parquet(latest_file, df)
-
-
-def locate_latest_silver(
-    dataset_prefix: str,
-    silver_table_prefix: str,
-    layer_prefix: str = "silver",
-) -> str:
-    """Locate the latest silver parquet file.
-
-    Args:
-        dataset_prefix (str): Dataset identifier used to namespace storage.
-        silver_table_prefix (str): Table name used to namespace storage.
-        layer_prefix (str): Storage namespace representing the data layer.
-            Defaults to "silver".
-
-    Raises:
-        FileNotFoundError: If the prefix or files do not exist.
-
-    Returns:
-        str: URI of the latest silver parquet file.
-    """
-    return _locate_latest(dataset_prefix, silver_table_prefix, layer_prefix)
 
 
 def read_parquet(parquet_uri: str) -> pd.DataFrame:


### PR DESCRIPTION
Very small PR addressing issue #63.

The following changes have been implemented:
- `locate_latest_bronze` and `locate_latest_silver` have been consolidated into a single `locate_latest` where the `layer_prefix` is now a required argument
- docstring has been updated
- all call sites in all pipelines have been updated

After these changes, I've verified that all pipelines run successfully locally.