### PR TITLE
new feature: add charge restriction period normalisation and validation

### DIFF
--- a/asf_mission_data/pipeline/energy_price_cap_levels_annex_9/config.py
+++ b/asf_mission_data/pipeline/energy_price_cap_levels_annex_9/config.py
@@ -13,6 +13,7 @@ PRICE_CAP_PERIOD_INTERVAL_PATTERN = (
     r"(?P<start_day>\d{1,2})\s+(?P<start_month>[A-Za-z]+)\s+to\s+(?P<end_day>\d{1,2})\s+(?P<end_month>[A-Za-z]+)\s+(?P<year>\d{4})"
 )
 
+# Expected publication dates
 PRICE_CAP_PERIOD_PUBLICATION_DATES = {
     "1 January to 31 March 2026": "2025-11-21",
     "1 April to 30 June 2026": "2026-02-25",
@@ -34,6 +35,22 @@ PRICE_CAP_PERIOD_PUBLICATION_DATES = {
     "1 April to 30 June 2030": "2030-02-27",
     "1 July to 30 September 2030": "2030-05-29",
     "1 October to 31 December 2030": "2030-08-28",
+}
+
+# For 28AD Charge Restriction Period string formatting
+MONTH_NORMALISATION = {
+    "April": "Apr",
+    "June": "Jun",
+    "September": "Sep",
+    "Sept": "Sep",
+    "July": "Jul",
+    "January": "Jan",
+    "February": "Feb",
+    "March": "Mar",
+    "August": "Aug",
+    "October": "Oct",
+    "November": "Nov",
+    "December": "Dec",
 }
 
 # Excel sheet name - Silver table Hamilton output node

--- a/asf_mission_data/pipeline/energy_price_cap_levels_annex_9/silver.py
+++ b/asf_mission_data/pipeline/energy_price_cap_levels_annex_9/silver.py
@@ -12,11 +12,11 @@ from hamilton.function_modifiers import (
 
 from asf_mission_data import storage, utils
 from asf_mission_data.logging_utils import setup_logging
-from asf_mission_data.pipeline.energy_price_cap_levels_annex_9.config import PRICE_CAP_PERIOD_PUBLICATION_DATES
+from asf_mission_data.pipeline.energy_price_cap_levels_annex_9.config import MONTH_NORMALISATION, PRICE_CAP_PERIOD_PUBLICATION_DATES
 from asf_mission_data.pipeline.energy_price_cap_levels_annex_9.schemas import (
     SILVER_1C_CONSUMPTION_ADJUSTED_LEVELS_SCHEMA,
 )
-from asf_mission_data.pipeline.energy_price_cap_levels_annex_9.validators import PriceCapValidator
+from asf_mission_data.pipeline.energy_price_cap_levels_annex_9.validators import ChargeRestrictionPeriodValidator, PriceCapValidator
 
 logger = setup_logging(__name__)
 
@@ -416,6 +416,7 @@ def fuel_payment_method_tidy_df(
     return pd.concat([melted_fuel_nil_consumption_df, melted_fuel_typical_consumption_df]).dropna(subset={"Tariff component"})
 
 
+@check_output_custom(ChargeRestrictionPeriodValidator())
 def all_tariff_tables_tidy_df(
     electricity_single_rate_other_payment_method_tidy_df: pd.DataFrame,
     electricity_multi_register_other_payment_method_tidy_df: pd.DataFrame,
@@ -452,7 +453,13 @@ def all_tariff_tables_tidy_df(
         gas_ppm_tidy_df,
         dual_fuel_ppm_tidy_df,
     ]
-    return pd.concat(all_dfs, ignore_index=True)
+
+    # Standardise price cap period string
+    df = pd.concat(all_dfs, ignore_index=True)
+    df["28AD Charge Restriction Period"] = df["28AD Charge Restriction Period"].apply(
+        lambda x: utils.normalise_charge_restriction_period(x, MONTH_NORMALISATION)
+    )
+    return df
 
 
 @extract_columns(
@@ -522,6 +529,7 @@ def all_tariff_tables_tidy_with_metadata_df(
     for col in string_cols:
         if col in df.columns:
             df[col] = df[col].astype(str)
+
     return df
 
 

--- a/asf_mission_data/pipeline/energy_price_cap_levels_annex_9/validators.py
+++ b/asf_mission_data/pipeline/energy_price_cap_levels_annex_9/validators.py
@@ -249,3 +249,31 @@ class TariffComponentsTotalValidator(DataValidator):
             passes=valid,
             message=f"Tariff components must sum to Total_GB average for column '{self.value_col}'.",
         )
+
+
+class ChargeRestrictionPeriodValidator(DataValidator):
+    """Checks that all 28AD Charge Restriction Period values are in normalised format (MMM YYYY - MMM YYYY)."""
+
+    def __init__(self, importance: str = "fail"):
+        super().__init__(importance=importance)
+        self.pattern = r"^[A-Z][a-z]{2} \d{4} - [A-Z][a-z]{2} \d{4}$"
+
+    def applies_to(self, datatype: type) -> bool:
+        return datatype is pd.DataFrame
+
+    def description(self) -> str:
+        return "Checks that all 28AD Charge Restriction Period values are in normalised format: 'MMM YYYY - MMM YYYY'."
+
+    @classmethod
+    def name(cls) -> str:
+        return "ChargeRestrictionPeriodValidator"
+
+    def validate(self, data: pd.DataFrame) -> ValidationResult:
+        invalid = data[~data["28AD Charge Restriction Period"].str.match(self.pattern)]["28AD Charge Restriction Period"].unique().tolist()
+
+        if invalid:
+            return ValidationResult(
+                passes=False,
+                message=f"Found non-normalised charge restriction periods: {invalid}",
+            )
+        return ValidationResult(passes=True, message="All charge restriction periods are correctly normalised.")

--- a/asf_mission_data/utils.py
+++ b/asf_mission_data/utils.py
@@ -162,6 +162,13 @@ def convert_energy_price_cap_charge_restriction_period_string_to_interval(
         raise ValueError("Charge restriction period string '%s' does not match expected regex pattern.")
 
 
+def normalise_charge_restriction_period(period: str, month_map: dict[str, str]) -> str:
+    """Normalise charge restriction period string to consistent abbreviated format."""
+    for full, abbrev in month_map.items():
+        period = period.replace(full, abbrev)
+    return period
+
+
 def normalise_date_string(date_str: str) -> str:
     """Convert a date string from 'DD Month YYYY' format to 'YYYY-MM-DD'.
 


### PR DESCRIPTION
Fixes issue #39 

- Added `MONTH_NORMALISATION` map to config to standardise inconsistent month formats in source data (full names, abbreviations, typos)
- Added `normalise_charge_restriction_period` utility function to apply the normalisation
- Applied normalisation to `"28AD Charge Restriction Period"` column in `all_tariff_tables_tidy_df`
- Added `ChargeRestrictionPeriodValidator` to validate all periods are in `MMM YYYY - MMM YYYY` format after normalisation

Checks:

- [x] Verified pipeline runs successfully

