### PR TITLE
refactor: move silver tables node map to config

### DIFF
--- a/asf_mission_data/pipeline/heat_pump_deployment_statistics/config.py
+++ b/asf_mission_data/pipeline/heat_pump_deployment_statistics/config.py
@@ -8,6 +8,12 @@ COLLECTION_URL = "https://www.gov.uk/government/collections/heat-pump-deployment
 PAGE_LINK_TEXT = "Heat pump deployment statistics:"
 FILE_LINK_TEXT = "Heat pump deployment statistics:"
 
+# Excel sheet name - Silver table Hamilton output node
+SILVER_TABLES_NODES_MAP = {
+    "Table 1.1": "silver_heat_pump_deployment_statistics_table_1_1_parquet",
+    "Table 1.2": "silver_heat_pump_deployment_statistics_table_1_2_parquet",
+}
+
 # Table 1.1
 TABLE_1_1_VALUE_VARS = [
     "Air-to-water heat pump installations",

--- a/asf_mission_data/pipeline/heat_pump_deployment_statistics/pipeline.py
+++ b/asf_mission_data/pipeline/heat_pump_deployment_statistics/pipeline.py
@@ -16,6 +16,7 @@ from asf_mission_data.pipeline.heat_pump_deployment_statistics.config import (
     FILE_LINK_TEXT,
     PAGE_LINK_TEXT,
     PUBLISHER,
+    SILVER_TABLES_NODES_MAP,
 )
 
 logger = setup_logging(__name__)
@@ -88,12 +89,7 @@ def run_silver_pipeline() -> None:
     DAG visualiation images are also generated and loaded to storage.
     """
 
-    tables = [
-        ("Table 1.1", "silver_heat_pump_deployment_statistics_table_1_1_parquet"),
-        ("Table 1.2", "silver_heat_pump_deployment_statistics_table_1_2_parquet"),
-    ]
-
-    for sheet_name, output_node in tables:
+    for sheet_name, output_node in SILVER_TABLES_NODES_MAP.items():
         driver = build_silver_driver(sheet_name=sheet_name)
 
         results = driver.execute([output_node, "latest_publication_date"])


### PR DESCRIPTION
Fixes issue #72 

Moves the hardcoded silver tables and output node names from `pipeline.py` into `SILVER_TABLES_NODES_MAP` in `config.py`, matching the pattern used in the energy price cap pipeline.

- [x] Verified that the pipeline runs successfully.