### PR TITLE
85 energy price cap levels annex 9/oct 2026 changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
 
     ### Python Tools ###
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.1
+    rev: v0.16.3
     hooks:
     -   id: ruff-check
         args: [--fix]
@@ -30,7 +30,7 @@ repos:
         name: "🐍 python · Format with Ruff"
 
 -   repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.25
+    rev: '0.26'
     hooks:
     -   id: validate-pyproject
         name: "🐍 python · Validate pyproject.toml"
@@ -38,7 +38,7 @@ repos:
 
     ### Data & Config Validation ###
 -   repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.4
+    rev: 0.38.0
     hooks:
     -   id: check-github-workflows
         name: "🐙 github-actions · Validate gh workflow files"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
 
     ### Python Tools ###
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.3
+    rev: v0.16.4
     hooks:
     -   id: ruff-check
         args: [--fix]

--- a/asf_mission_data/pipeline/energy_price_cap_levels_annex_9/config.py
+++ b/asf_mission_data/pipeline/energy_price_cap_levels_annex_9/config.py
@@ -57,12 +57,15 @@ MONTH_NORMALISATION = {
 SILVER_TABLES_NODES_MAP = {"1c Consumption adjusted levels": "silver_energy_price_cap_annex_9_1c_consumption_adjusted_levels_parquet"}
 
 BENCHMARK_CONSUMPTION = {  # MWh per year
-    "Gas": 11.5,
-    "Electricity: Single-Rate Metering Arrangement": 2.7,
-    "Electricity: Multi-Register Metering Arrangement": 3.9,
+    "Gas": 9.5,  # old TDCV before July 26 change was 11.5
+    "Electricity: Single-Rate Metering Arrangement": 2.5,  # old TDCV before July 26 change was 2.7
+    "Electricity: Multi-Register Metering Arrangement": 3.4,  # old TDCV before July 26 change was 3.9
 }
 
 VAT = 0.05
+
+# 28AD Charge Restriction Period start dates for which VAT is zero-rated on electricity bill instead of the standard VAT rate
+ZERO_VAT_PERIOD_STARTS = ["2026-10-01", "2027-01-01"]
 
 COMPONENT_CATEGORY_MAP = {
     "DF": "Wholesale",  # Direct fuel

--- a/asf_mission_data/pipeline/energy_price_cap_levels_annex_9/config.py
+++ b/asf_mission_data/pipeline/energy_price_cap_levels_annex_9/config.py
@@ -64,9 +64,6 @@ BENCHMARK_CONSUMPTION = {  # MWh per year
 
 VAT = 0.05
 
-# 28AD Charge Restriction Period start dates for which VAT is zero-rated on electricity bill instead of the standard VAT rate
-ZERO_VAT_PERIOD_STARTS = ["2026-10-01", "2027-01-01"]
-
 COMPONENT_CATEGORY_MAP = {
     "DF": "Wholesale",  # Direct fuel
     "CM": "Wholesale",  # Capacity market

--- a/asf_mission_data/pipeline/energy_price_cap_levels_annex_9/gold.py
+++ b/asf_mission_data/pipeline/energy_price_cap_levels_annex_9/gold.py
@@ -14,6 +14,7 @@ from asf_mission_data.pipeline.energy_price_cap_levels_annex_9.config import (
     BENCHMARK_CONSUMPTION,
     COMPONENT_CATEGORY_MAP,
     VAT,
+    ZERO_VAT_PERIOD_STARTS,
 )
 from asf_mission_data.pipeline.energy_price_cap_levels_annex_9.schemas import (
     GOLD_1C_CONSUMPTION_ADJUSTED_LEVELS_WITH_VAT_SCHEMA,
@@ -77,6 +78,13 @@ def consumption_adjusted_levels_with_vat_df(
     `Total_GB average` component) and adds it as a separate row. It also uprates
     the `Total_GB average` values so that they include VAT.
 
+    UK government announced that VAT will be removed from electricity from
+    Oct 2026 to end of that financial year. Electricity is zero-rated during periods
+    in ZERO_VAT_PERIOD_STARTS. Gas remains subject to VAT during those periods.
+    Dual fuel VAT is derived directly from the raw `Total inc VAT` figure, since
+    that figure already reflects the correct combination of zero-rated electricity
+    and taxed gas.
+
     Args:
         silver_df (pd.DataFrame): Silver-layer Annex 9 DataFrame containing tariff
             components, consumption levels, and annual values before VAT
@@ -88,26 +96,61 @@ def consumption_adjusted_levels_with_vat_df(
         that include VAT.
     """
 
-    # Add VAT as individual tariff component
-    if not silver_df["Tariff component"].eq("Total_GB average").any():
+    # Total_GB average value used to calculate VAT component
+    total_mask = silver_df["Tariff component"].eq("Total_GB average")
+
+    if not total_mask.any():
         raise ValueError("Expected tariff component 'Total_GB average' not found in silver_df.")
 
-    vat_rows = silver_df[silver_df["Tariff component"] == "Total_GB average"].copy()
+    totals = silver_df.loc[total_mask].copy()
+
+    # Identify zero-VAT periods and individual-meter fuel types (as opposed to dual fuel)
+    zero_vat_period = totals["28AD Charge Restriction Period start"].isin(pd.to_datetime(ZERO_VAT_PERIOD_STARTS))
+    electricity_mask = totals["Fuel"].isin(
+        [
+            "Electricity: Single-Rate Metering Arrangement",
+            "Electricity: Multi-Register Metering Arrangement",
+        ]
+    )
+    gas_mask = totals["Fuel"].eq("Gas")
+    dual_fuel_mask = totals["Fuel"].eq("Dual fuel (implied)")
+
+    # Electricity is zero-rated during zero-VAT periods; gas always uses the standard rate
+    vat_rate = pd.Series(VAT, index=totals.index)
+    vat_rate.loc[zero_vat_period & electricity_mask] = 0
+
+    # VAT for electricity single/multi-register and gas rows: Total_GB average * rate
+    totals["vat_value"] = 0.0
+    individual_fuel_mask = electricity_mask | gas_mask
+    totals.loc[individual_fuel_mask, "vat_value"] = totals.loc[individual_fuel_mask, "value"] * vat_rate.loc[individual_fuel_mask]
+
+    # VAT for dual fuel rows: Total inc VAT - Total_GB average, taken directly from the raw silver data
+    # We are trusting that Ofgem will calculate Total inc VAT correctly for dual fuel in the periods with
+    # zero-VAT electricity
+    match_columns = [
+        "Payment method",
+        "Consumption",
+        "28AD Charge Restriction Period start",
+    ]
+    total_inc_vat = silver_df.loc[silver_df["Tariff component"].eq("Total inc VAT")].set_index(match_columns)["value"]
+    dual_fuel_index = pd.MultiIndex.from_frame(totals.loc[dual_fuel_mask, match_columns])
+    totals.loc[dual_fuel_mask, "vat_value"] = total_inc_vat.loc[dual_fuel_index].to_numpy() - totals.loc[dual_fuel_mask, "value"].to_numpy()
+
+    # Add VAT as an individual tariff component to table
+    vat_rows = totals.copy()
     vat_rows["Tariff component"] = "VAT"
-    vat_rows["value"] *= VAT
+    vat_rows["value"] = vat_rows["vat_value"]
+    vat_rows = vat_rows.drop(columns="vat_value")
 
-    # Uprate Total_GB average to include VAT
-    uprated_silver_df = silver_df.copy()
+    # Uprate Total_GB average to include VAT; for dual fuel this reproduces Total inc VAT exactly
+    result = silver_df.copy()
+    result.loc[total_mask, "value"] += totals["vat_value"]
 
-    uprated_silver_df.loc[
-        (uprated_silver_df["Tariff component"] == "Total_GB average"),
-        "value",
-    ] *= 1 + VAT
+    # Remove now redundant "Total inc VAT" rows that were only previously present in
+    # the Dual fuel table
+    result = result[result["Tariff component"].ne("Total inc VAT")]
 
-    # Remove now redundant "Total inc VAT" rows that were present only in the Dual fuel table
-    uprated_silver_df = uprated_silver_df[uprated_silver_df["Tariff component"] != "Total inc VAT"]
-
-    return pd.concat([uprated_silver_df, vat_rows], ignore_index=True)
+    return pd.concat([result, vat_rows], ignore_index=True)
 
 
 @check_output(

--- a/asf_mission_data/pipeline/energy_price_cap_levels_annex_9/gold.py
+++ b/asf_mission_data/pipeline/energy_price_cap_levels_annex_9/gold.py
@@ -13,8 +13,6 @@ from asf_mission_data import storage, utils
 from asf_mission_data.pipeline.energy_price_cap_levels_annex_9.config import (
     BENCHMARK_CONSUMPTION,
     COMPONENT_CATEGORY_MAP,
-    VAT,
-    ZERO_VAT_PERIOD_STARTS,
 )
 from asf_mission_data.pipeline.energy_price_cap_levels_annex_9.schemas import (
     GOLD_1C_CONSUMPTION_ADJUSTED_LEVELS_WITH_VAT_SCHEMA,
@@ -74,83 +72,70 @@ def consumption_adjusted_levels_with_vat_df(
     """Add VAT as a tariff component and uprate the total values to include VAT.
 
     This function derives VAT-inclusive tariff values from the silver dataset, and
-    creates a new tariff component representing VAT (calculated as 5% of the
-    `Total_GB average` component) and adds it as a separate row. It also uprates
-    the `Total_GB average` values so that they include VAT.
-
-    UK government announced that VAT will be removed from electricity from
-    Oct 2026 to end of that financial year. Electricity is zero-rated during periods
-    in ZERO_VAT_PERIOD_STARTS. Gas remains subject to VAT during those periods.
-    Dual fuel VAT is derived directly from the raw `Total inc VAT` figure, since
-    that figure already reflects the correct combination of zero-rated electricity
-    and taxed gas.
+    creates a new tariff component representing VAT (calculated as the difference
+    between the `Total inc VAT` and `Total_GB average` components) and adds it as
+    a separate row. It also uprates the `Total_GB average` values so that they
+    include VAT, using the corresponding `Total inc VAT` values.
 
     Args:
         silver_df (pd.DataFrame): Silver-layer Annex 9 DataFrame containing tariff
             components, consumption levels, and annual values before VAT
-            adjustments.
+            adjustments. Must contain both `Total_GB average` and
+            `Total inc VAT` tariff components for every fuel.
 
     Returns:
-        pd.DataFrame: DataFrame containing the original tariff components,
-        VAT as a separate component, and updated `Total_GB average` values
-        that include VAT.
+        pd.DataFrame: DataFrame containing the original tariff components
+        (excluding `Total inc VAT`), VAT as a separate component, and updated
+        `Total_GB average` values that include VAT.
     """
+    for component in ("Total_GB average", "Total inc VAT"):
+        if not silver_df["Tariff component"].eq(component).any():
+            raise ValueError(f"Expected tariff component '{component}' not found in silver_df.")
 
-    # Total_GB average value used to calculate VAT component
-    total_mask = silver_df["Tariff component"].eq("Total_GB average")
-
-    if not total_mask.any():
-        raise ValueError("Expected tariff component 'Total_GB average' not found in silver_df.")
-
-    totals = silver_df.loc[total_mask].copy()
-
-    # Identify zero-VAT periods and individual-meter fuel types (as opposed to dual fuel)
-    zero_vat_period = totals["28AD Charge Restriction Period start"].isin(pd.to_datetime(ZERO_VAT_PERIOD_STARTS))
-    electricity_mask = totals["Fuel"].isin(
-        [
-            "Electricity: Single-Rate Metering Arrangement",
-            "Electricity: Multi-Register Metering Arrangement",
-        ]
-    )
-    gas_mask = totals["Fuel"].eq("Gas")
-    dual_fuel_mask = totals["Fuel"].eq("Dual fuel (implied)")
-
-    # Electricity is zero-rated during zero-VAT periods; gas always uses the standard rate
-    vat_rate = pd.Series(VAT, index=totals.index)
-    vat_rate.loc[zero_vat_period & electricity_mask] = 0
-
-    # VAT for electricity single/multi-register and gas rows: Total_GB average * rate
-    totals["vat_value"] = 0.0
-    individual_fuel_mask = electricity_mask | gas_mask
-    totals.loc[individual_fuel_mask, "vat_value"] = totals.loc[individual_fuel_mask, "value"] * vat_rate.loc[individual_fuel_mask]
-
-    # VAT for dual fuel rows: Total inc VAT - Total_GB average, taken directly from the raw silver data
-    # We are trusting that Ofgem will calculate Total inc VAT correctly for dual fuel in the periods with
-    # zero-VAT electricity
-    match_columns = [
+    # Columns that uniquely identify a row aside from "Tariff component",
+    # "value" and "metadata"
+    key_cols = [
         "Payment method",
+        "Fuel",
         "Consumption",
+        "28AD Charge Restriction Period",
         "28AD Charge Restriction Period start",
+        "28AD Charge Restriction Period end",
+        "28AD Charge Restriction Period interval",
     ]
-    total_inc_vat = silver_df.loc[silver_df["Tariff component"].eq("Total inc VAT")].set_index(match_columns)["value"]
-    dual_fuel_index = pd.MultiIndex.from_frame(totals.loc[dual_fuel_mask, match_columns])
-    totals.loc[dual_fuel_mask, "vat_value"] = total_inc_vat.loc[dual_fuel_index].to_numpy() - totals.loc[dual_fuel_mask, "value"].to_numpy()
 
-    # Add VAT as an individual tariff component to table
-    vat_rows = totals.copy()
+    total_gb_avg = silver_df[silver_df["Tariff component"] == "Total_GB average"].copy()
+    total_inc_vat = silver_df[silver_df["Tariff component"] == "Total inc VAT"].copy()
+
+    merged = total_gb_avg.merge(
+        total_inc_vat[key_cols + ["value"]],
+        on=key_cols,
+        how="left",
+        suffixes=("", "_inc_vat"),
+        validate="one_to_one",
+    )
+
+    if merged["value_inc_vat"].isna().any():
+        raise ValueError("Some 'Total_GB average' rows have no matching 'Total inc VAT' row.")
+
+    # VAT component = Total inc VAT - Total_GB average
+    vat_rows = merged.copy()
+    vat_rows["value"] = vat_rows["value_inc_vat"] - vat_rows["value"]
     vat_rows["Tariff component"] = "VAT"
-    vat_rows["value"] = vat_rows["vat_value"]
-    vat_rows = vat_rows.drop(columns="vat_value")
+    vat_rows = vat_rows.drop(columns="value_inc_vat")
 
-    # Uprate Total_GB average to include VAT; for dual fuel this reproduces Total inc VAT exactly
-    result = silver_df.copy()
-    result.loc[total_mask, "value"] += totals["vat_value"]
+    # Uprated Total_GB average = Total inc VAT value
+    uprated_total_gb_avg = merged.copy()
+    uprated_total_gb_avg["value"] = uprated_total_gb_avg["value_inc_vat"]
+    uprated_total_gb_avg = uprated_total_gb_avg.drop(columns="value_inc_vat")
 
-    # Remove now redundant "Total inc VAT" rows that were only previously present in
-    # the Dual fuel table
-    result = result[result["Tariff component"].ne("Total inc VAT")]
+    # All other rows, unchanged (drop original Total_GB average and Total inc VAT rows)
+    other_rows = silver_df[~silver_df["Tariff component"].isin(["Total_GB average", "Total inc VAT"])].copy()
 
-    return pd.concat([result, vat_rows], ignore_index=True)
+    return pd.concat(
+        [other_rows, uprated_total_gb_avg, vat_rows],
+        ignore_index=True,
+    )
 
 
 @check_output(

--- a/asf_mission_data/pipeline/energy_price_cap_levels_annex_9/oct_2026_changes_checks.py
+++ b/asf_mission_data/pipeline/energy_price_cap_levels_annex_9/oct_2026_changes_checks.py
@@ -10,6 +10,11 @@ from asf_mission_data.pipeline.energy_price_cap_levels_annex_9.config import (
 )
 
 # %%
+silver_df = storage.read_parquet(
+    "s3://asf-mission-data-dev/data/silver/energy_price_cap_levels/annex_9/latest/1c_consumption_adjusted_levels/1c_consumption_adjusted_levels.parquet"
+)
+
+# %%
 start_date_to_check = "2026-10-01"
 
 # %%
@@ -95,7 +100,7 @@ df[
 
 # %%
 electricity_tdcv = BENCHMARK_CONSUMPTION.get("Electricity: Single-Rate Metering Arrangement") * 1_000  # kWh/year
-electricity_unit_rate = 26.110065  # p/kWh
+electricity_unit_rate = 26.322252  # p/kWh
 electricity_tdcv * electricity_unit_rate / 100  # should match annual consumption-based cost
 
 # %%
@@ -109,7 +114,7 @@ df[
 
 # %%
 gas_tdcv = BENCHMARK_CONSUMPTION.get("Gas") * 1_000  # kWh/year
-gas_unit_rate = 7.325091  # p/kWh
+gas_unit_rate = 7.966458  # p/kWh
 gas_tdcv * gas_unit_rate / 100  # should match annual consumption-based cost
 
 # %%

--- a/asf_mission_data/pipeline/energy_price_cap_levels_annex_9/oct_2026_changes_checks.py
+++ b/asf_mission_data/pipeline/energy_price_cap_levels_annex_9/oct_2026_changes_checks.py
@@ -1,0 +1,115 @@
+# %% [markdown]
+# ### Checks for TDCV and electricity VAT changes for Oct - Dec 2026 and Jan - Mar 2027 price cap periods
+
+# %%
+import pandas as pd
+
+from asf_mission_data import storage
+from asf_mission_data.pipeline.energy_price_cap_levels_annex_9.config import (
+    BENCHMARK_CONSUMPTION,
+)
+
+# %%
+start_date_to_check = "2026-10-01"
+
+# %%
+# Levels table checks
+gold_levels_df = storage.read_parquet(
+    "s3://asf-mission-data-dev/data/gold/energy_price_cap_levels/annex_9/latest/1c_consumption_adjusted_levels_with_vat/1c_consumption_adjusted_levels_with_vat.parquet"
+)
+df = gold_levels_df
+
+# %%
+# VAT check, should be zero
+df[
+    (df["28AD Charge Restriction Period start"] == pd.to_datetime(start_date_to_check))
+    & (df["Consumption"] == "Typical consumption")
+    & (df["Payment method"] == "Other Payment Method")
+    & (df["Fuel"] == "Electricity: Single-Rate Metering Arrangement")
+    & (df["Tariff component"] == "VAT")
+]
+
+# %%
+# Total bill check, should match final dual fuel bill matches what is published on Ofgem page
+df = gold_levels_df
+df[
+    (df["28AD Charge Restriction Period start"] == pd.to_datetime(start_date_to_check))
+    & (df["Consumption"] == "Typical consumption")
+    & (df["Payment method"] == "Other Payment Method")
+    & (df["Fuel"] == "Dual fuel (implied)")
+    & (df["Tariff component"] == "Total_GB average")
+]
+
+# %%
+# Electricity bill check
+df = gold_levels_df
+df[
+    (df["28AD Charge Restriction Period start"] == pd.to_datetime(start_date_to_check))
+    & (df["Consumption"] == "Typical consumption")
+    & (df["Payment method"] == "Other Payment Method")
+    & (df["Fuel"] == "Electricity: Single-Rate Metering Arrangement")
+    & (df["Tariff component"] == "Total_GB average")
+]
+
+# %%
+# Component rates and standing charges check
+gold_tariff_component_rates_df = storage.read_parquet(
+    "s3://asf-mission-data-dev/data/gold/energy_price_cap_levels/annex_9/latest/tariff_component_rates/tariff_component_rates.parquet"
+)
+df = gold_tariff_component_rates_df
+
+# %%
+# Electricity checks
+df[
+    (df["28AD Charge Restriction Period start"] == pd.to_datetime(start_date_to_check))
+    & (df["Payment method"] == "Other Payment Method")
+    & (df["Fuel"] == "Electricity: Single-Rate Metering Arrangement")
+    & (df["Tariff component"] == "Total_GB average")
+]
+
+# %%
+# Gas checks
+df[
+    (df["28AD Charge Restriction Period start"] == pd.to_datetime(start_date_to_check))
+    & (df["Payment method"] == "Other Payment Method")
+    & (df["Fuel"] == "Gas")
+    & (df["Tariff component"] == "Total_GB average")
+]
+
+# %%
+# Check annual_bill_fixed_and_variable_contributions_df
+# Consumption-based cost (£/yr) should match the unit rate (incl VAT) * TDCV
+gold_annual_bill_fixed_and_variable_contributions_df = storage.read_parquet(
+    "s3://asf-mission-data-dev/data/gold/energy_price_cap_levels/annex_9/latest/annual_bill_fixed_and_variable_component_contributions/annual_bill_fixed_and_variable_component_contributions.parquet"
+)
+df = gold_annual_bill_fixed_and_variable_contributions_df
+
+# %%
+# Electricity checks
+df[
+    (df["28AD Charge Restriction Period start"] == pd.to_datetime(start_date_to_check))
+    & (df["Payment method"] == "Other Payment Method")
+    & (df["Fuel"] == "Electricity: Single-Rate Metering Arrangement")
+    & (df["Tariff component"] == "Total_GB average")
+]
+
+# %%
+electricity_tdcv = BENCHMARK_CONSUMPTION.get("Electricity: Single-Rate Metering Arrangement") * 1_000  # kWh/year
+electricity_unit_rate = 26.110065  # p/kWh
+electricity_tdcv * electricity_unit_rate / 100  # should match annual consumption-based cost
+
+# %%
+# Gas checks
+df[
+    (df["28AD Charge Restriction Period start"] == pd.to_datetime(start_date_to_check))
+    & (df["Payment method"] == "Other Payment Method")
+    & (df["Fuel"] == "Gas")
+    & (df["Tariff component"] == "Total_GB average")
+]
+
+# %%
+gas_tdcv = BENCHMARK_CONSUMPTION.get("Gas") * 1_000  # kWh/year
+gas_unit_rate = 7.325091  # p/kWh
+gas_tdcv * gas_unit_rate / 100  # should match annual consumption-based cost
+
+# %%


### PR DESCRIPTION
<!-- PR template for merges to dev -->

---

## Description
Changes to gold node 1c_consumption_adjusted_levels_df to process VAT differently (now that VAT has come off electricity until the end of the FY), and changes to config as TDCV benchmark consumption values have changed.

Fixes #85

## Type of change

- [ ] New pipeline
- [x] Change to an existing pipeline
- [ ] Package / infrastructure change
- [ ] Docs only

## Checklist

- [x] `uv run pytest` passes locally
- [x] `uv run pre-commit run --all-files` passes (ruff, gitleaks, etc.)
- [ ] If this adds a new pipeline: it's registered in `pipelines.yaml` and has its own `README.md`
- [x] I've merged the latest `dev` into this branch

## Testing notes

Tested pipeline in dev using GHA, verified gold data tables using the `oct_2026_changes_checks.py` notebook where Oct-Dec 2026 values are as expected (also checked against values published on the Ofgem page).

## Instructions for reviewer

<!-- Anything they should pay particular attention to -->
